### PR TITLE
Replace deprecated datetime.utcnow() with timezone-aware equivalent

### DIFF
--- a/src/oaipmh/server.py
+++ b/src/oaipmh/server.py
@@ -1,6 +1,6 @@
 from lxml.etree import ElementTree, Element, SubElement
 from lxml import etree
-from datetime import datetime
+from datetime import datetime, timezone
 try:
     from urllib.parse import urlencode, quote, unquote
 except ImportError:
@@ -173,8 +173,12 @@ class XMLTreeServer(object):
         e_tree = ElementTree(element=e_oaipmh)
         e_responseDate = SubElement(e_oaipmh, nsoai('responseDate'))
         # date should be first possible moment
+        # datetime.utcnow() is deprecated since Python 3.12 and scheduled
+        # for removal. datetime_to_datestamp() requires a naive datetime
+        # (it asserts dt.tzinfo is None), so convert the aware UTC
+        # value back to naive before passing it in.
         e_responseDate.text = datetime_to_datestamp(
-            datetime.utcnow().replace(microsecond=0))
+            datetime.now(timezone.utc).replace(microsecond=0, tzinfo=None))
         e_request = SubElement(e_oaipmh, nsoai('request'))
         for key, value in kw.items():
             if key == 'from_':


### PR DESCRIPTION
`datetime.datetime.utcnow()` is deprecated since Python 3.12 and scheduled for removal in a future version:

    DeprecationWarning: datetime.datetime.utcnow() is deprecated and
    scheduled for removal in a future version. Use timezone-aware
    objects to represent datetimes in UTC:
    datetime.datetime.now(datetime.UTC).

`datetime_to_datestamp()` in `oaipmh/datestamp.py` asserts that the input has `tzinfo is None`, so we convert the timezone-aware UTC value back to naive with `.replace(tzinfo=None)` before passing it in. The resulting `responseDate` string in the OAI-PMH response is unchanged.

This is the only `datetime.utcnow()` call in the codebase; after this change, pyoai no longer emits `DeprecationWarning` for it on Python 3.12+.